### PR TITLE
feature/fix-myip-result

### DIFF
--- a/myip/myip.go
+++ b/myip/myip.go
@@ -4,6 +4,7 @@ package myip
 import (
 	"net/http"
 	"io"
+	"strings"
 )
 
 const (
@@ -25,5 +26,5 @@ func GetMyIP() string {
 		return ""
 	}
 
-	return string(b)
+	return strings.Trim(string(b), "\n")
 }


### PR DESCRIPTION
* IPアドレス取得結果の末尾に改行が含まれている場合に削除するように修正